### PR TITLE
Harmonize primus & ws versions in client & server

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "grunt-contrib-uglify": "^4.0.0",
     "jade": "^1.11.0",
     "lodash": "3.10.1",
-    "primus": "^7.3.1",
-    "primus-emit": "^1.0.0",
-    "primus-spark-latency": "^0.1.1",
-    "ws": "^6.1.2"
+    "primus": "7.3.2",
+    "primus-emit": "1.0.0",
+    "primus-spark-latency": "0.1.1",
+    "ws": "6.2.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Primus and WS Versions on client and server should match, to avoid disconnects.

See also https://github.com/trustlines-network/ethstats-client/pull/5